### PR TITLE
Use recursive search for executables

### DIFF
--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,0 +1,47 @@
+import sys
+import types
+import os
+
+# Ensure the project root is on sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Create dummy modules to satisfy imports in utility.py
+Rhino = types.ModuleType('Rhino')
+Rhino.RhinoDoc = types.SimpleNamespace(ActiveDoc=None)
+sys.modules['Rhino'] = Rhino
+sys.modules['Rhino.Geometry'] = types.ModuleType('Rhino.Geometry')
+
+ghpythonlib = types.ModuleType('ghpythonlib')
+ghpythonlib.components = types.ModuleType('components')
+sys.modules['ghpythonlib'] = ghpythonlib
+sys.modules['ghpythonlib.components'] = ghpythonlib.components
+
+from utility import find_BCA_exe_file, find_exe_files
+
+
+def test_find_BCA_exe_file_recursive(tmp_path, monkeypatch):
+    root1 = tmp_path / 'pf'
+    root2 = tmp_path / 'pf86'
+    nested = root1 / 'a' / 'b'
+    nested.mkdir(parents=True)
+    exe = nested / 'blueCFD-AIR.exe'
+    exe.write_text('')
+
+    monkeypatch.setenv('ProgramFiles', str(root1))
+    monkeypatch.setenv('ProgramFiles(x86)', str(root2))
+
+    assert find_BCA_exe_file() == str(exe)
+
+
+def test_find_exe_files_recursive(tmp_path, monkeypatch):
+    root1 = tmp_path / 'pf'
+    root2 = tmp_path / 'pf86'
+    nested = root2 / 'ParaView' / 'deep' / 'bin'
+    nested.mkdir(parents=True)
+    exe = nested / 'paraview.exe'
+    exe.write_text('')
+
+    monkeypatch.setenv('ProgramFiles', str(root1))
+    monkeypatch.setenv('ProgramFiles(x86)', str(root2))
+
+    assert find_exe_files('ParaView') == str(exe)

--- a/utility.py
+++ b/utility.py
@@ -56,13 +56,15 @@ def round_custom(float, times=2):
 
 def find_BCA_exe_file():
     """
-    查找指定目录及其子目录下的blueCFD-AIR..exe文件
+    查找指定目录及其子目录下的blueCFD-AIR.exe文件
     """
+    target = "blueCFD-AIR.exe"
     dir_paths = get_common_program_files()
     for dir_path in dir_paths:
-        for filename in os.listdir(dir_path):
-            if "blueCFD-AIR" in filename:
-                return dir_path + "\\blueCFD-AIR\\blueCFD-AIR.exe"
+        for root, _dirs, files in os.walk(dir_path):
+            for filename in files:
+                if filename.lower() == target.lower():
+                    return os.path.join(root, filename)
     raise ValueError("No exe file found in the folder.")
 
 
@@ -79,13 +81,15 @@ def find_exe_files(software="ParaView"):
     查找指定目录及其子目录下的.exe文件
     """
 
-    dict = {"blueCFD-AIR": "\\blueCFD-AIR.exe", "ParaView": "\\bin\\paraview.exe"}
+    target_map = {"blueCFD-AIR": "blueCFD-AIR.exe", "ParaView": "paraview.exe"}
+    if software not in target_map:
+        raise ValueError(f"Unsupported software: {software}")
+    target = target_map[software]
     dir_paths = get_common_program_files()
     for dir_path in dir_paths:
-        for filename in os.listdir(dir_path):
-            if software in filename:
-                folder = dir_path + "\\" + filename
-                return folder + dict[software]
+        for root, _dirs, files in os.walk(dir_path):
+            if target in files:
+                return os.path.join(root, target)
     raise ValueError("No exe file found in the folder.")
 
 


### PR DESCRIPTION
## Summary
- Search Program Files recursively for blueCFD-AIR and ParaView executables
- Add tests ensuring executables can be located in nested directories

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68957fef77f48329844cd24bc977c783